### PR TITLE
Add waiver for VPC flow logs

### DIFF
--- a/waivers/FG_R00054.rego
+++ b/waivers/FG_R00054.rego
@@ -1,0 +1,7 @@
+package fugue.regula.config
+
+waivers[waiver] {
+  waiver := {
+    "rule_id": "FG_R00054"
+  }
+}


### PR DESCRIPTION
https://github.com/fugue/regula/issues/393

This is causing Regula to fail erroneously when VPC flow logs are enabled. From looking through the state file while investigating this locally, it seems like this may be a bug in the upstream provider as opposed to an issue with Regula itself.