### PR TITLE
Add missing providers for lambda_function builds

### DIFF
--- a/policy/approved_providers.rego
+++ b/policy/approved_providers.rego
@@ -11,6 +11,10 @@ deny[msg] {
     resource_change.provider_name != "registry.terraform.io/hashicorp/kubernetes"
     resource_change.provider_name != "registry.terraform.io/hashicorp/helm"
     resource_change.provider_name != "registry.terraform.io/sumologic/sumologic"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/external"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/local"
+    resource_change.provider_name != "registry.terraform.io/hashicorp/null"
+    resource_change.provider_name != "terraform.io/builtin/terraform"    
 
     msg := sprintf("Provider is not allowed: %s", [resource_change.provider_name])
 }


### PR DESCRIPTION
Discovered these were missing while trying to get `make lint` working for a new module that orchestrates Python Lambdas on AWS.

We rely on the [terraform-aws-modules/lambda](https://registry.terraform.io/modules/terraform-aws-modules/lambda/aws/latest) community-supported module, which uses external, local, and null providers. Some examples of these being used are shown below:

external provider: https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/dc7c19b3f93b059eede1f9d5378793fdb5cfdf70/package.tf#L7

local provider: https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/dc7c19b3f93b059eede1f9d5378793fdb5cfdf70/package.tf#L49

null resource: https://github.com/terraform-aws-modules/terraform-aws-lambda/blob/dc7c19b3f93b059eede1f9d5378793fdb5cfdf70/package.tf#L59

Our module (not yet published) uses the `terraform_data` resource to run its scripts, which requires that we add the new `terraform.io/builtin/terraform` provider as well.